### PR TITLE
feat: support multiple user directories (desktop, documents, music, p…

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,39 @@ const path = require("path");
 const os = require("os");
 const fs = require("fs");
 
-function getXDGDownloadDir(configPath) {
+const XDG_KEYS = {
+    desktop: "XDG_DESKTOP_DIR",
+    downloads: "XDG_DOWNLOAD_DIR",
+    documents: "XDG_DOCUMENTS_DIR",
+    music: "XDG_MUSIC_DIR",
+    pictures: "XDG_PICTURES_DIR",
+    videos: "XDG_VIDEOS_DIR",
+};
+
+const MACOS_DEFAULTS = {
+    desktop: "Desktop",
+    downloads: "Downloads",
+    documents: "Documents",
+    music: "Music",
+    pictures: "Pictures",
+    videos: "Movies",
+};
+
+const DEFAULT_DIRS = {
+    desktop: "Desktop",
+    downloads: "Downloads",
+    documents: "Documents",
+    music: "Music",
+    pictures: "Pictures",
+    videos: "Videos",
+};
+
+function getXDGUserDir(key, configPath) {
     configPath = configPath || path.join(os.homedir(), ".config", "user-dirs.dirs");
     try {
         const content = fs.readFileSync(configPath, "utf8");
-        const match = content.match(/^XDG_DOWNLOAD_DIR="(.+)"$/m);
+        const regex = new RegExp('^' + key + '="(.+)"$', "m");
+        const match = content.match(regex);
         if (match) {
             return path.normalize(match[1].replace("$HOME", os.homedir()));
         }
@@ -16,15 +44,49 @@ function getXDGDownloadDir(configPath) {
     return null;
 }
 
-function downloads() {
+function resolve(name) {
+    const xdgKey = XDG_KEYS[name];
+    if (!xdgKey) {
+        throw new Error("Unknown directory: " + name + ". Valid names: " + Object.keys(XDG_KEYS).join(", "));
+    }
+
     if (process.platform === "linux") {
-        const xdgDir = getXDGDownloadDir();
+        const xdgDir = getXDGUserDir(xdgKey);
         if (xdgDir) {
             return xdgDir;
         }
     }
-    return path.join(os.homedir(), "Downloads");
+
+    const dirName = process.platform === "darwin"
+        ? MACOS_DEFAULTS[name]
+        : DEFAULT_DIRS[name];
+
+    return path.join(os.homedir(), dirName);
 }
 
+function getPath(name) {
+    return resolve(name);
+}
+
+function desktop() { return resolve("desktop"); }
+function downloads() { return resolve("downloads"); }
+function documents() { return resolve("documents"); }
+function music() { return resolve("music"); }
+function pictures() { return resolve("pictures"); }
+function videos() { return resolve("videos"); }
+
+// Backward compatibility: require("os-downloads")() returns Downloads path
 module.exports = downloads;
-module.exports.getXDGDownloadDir = getXDGDownloadDir;
+module.exports.getPath = getPath;
+module.exports.desktop = desktop;
+module.exports.downloads = downloads;
+module.exports.documents = documents;
+module.exports.music = music;
+module.exports.pictures = pictures;
+module.exports.videos = videos;
+module.exports.getXDGUserDir = getXDGUserDir;
+
+// Deprecated: kept for backward compatibility
+module.exports.getXDGDownloadDir = function (configPath) {
+    return getXDGUserDir("XDG_DOWNLOAD_DIR", configPath);
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "os-downloads",
   "version": "1.0.0",
-  "description": "Look up downloads directory specific to different operating systems.",
+  "description": "Get OS-specific user directories (Downloads, Desktop, Documents, Music, Pictures, Videos) with zero dependencies.",
   "main": "index.js",
   "scripts": {
     "test": "mocha test.js"
@@ -11,8 +11,17 @@
     "url": "git+https://github.com/piroz/os-downloads.git"
   },
   "keywords": [
-    "environment",
-    "downloads"
+    "os",
+    "directories",
+    "downloads",
+    "desktop",
+    "documents",
+    "music",
+    "pictures",
+    "videos",
+    "xdg",
+    "user-dirs",
+    "platform-folders"
   ],
   "author": "piroz",
   "license": "MIT",

--- a/test.js
+++ b/test.js
@@ -3,10 +3,19 @@ const path = require("path");
 const os = require("os");
 const fs = require("fs");
 const downloads = require("./");
-const { getXDGDownloadDir } = require("./");
+const {
+    getXDGDownloadDir,
+    getXDGUserDir,
+    getPath,
+    desktop,
+    documents,
+    music,
+    pictures,
+    videos,
+} = require("./");
 
 describe("os-downloads", () => {
-    describe("downloads", () => {
+    describe("downloads (default export / backward compatibility)", () => {
         it("returns a path ending with Downloads", () => {
             assert.ok(path.basename(downloads()).match(/downloads/i));
         });
@@ -20,7 +29,119 @@ describe("os-downloads", () => {
         });
     });
 
-    describe("getXDGDownloadDir", () => {
+    describe("named directory functions", () => {
+        const cases = [
+            { fn: desktop, name: "desktop" },
+            { fn: downloads, name: "downloads" },
+            { fn: documents, name: "documents" },
+            { fn: music, name: "music" },
+            { fn: pictures, name: "pictures" },
+            { fn: videos, name: "videos" },
+        ];
+
+        cases.forEach(({ fn, name }) => {
+            it(`${name}() returns an absolute path`, () => {
+                assert.ok(path.isAbsolute(fn()));
+            });
+
+            it(`${name}() starts with home directory`, () => {
+                assert.ok(fn().startsWith(os.homedir()));
+            });
+        });
+    });
+
+    describe("getPath", () => {
+        it("returns the same result as named functions", () => {
+            assert.strictEqual(getPath("desktop"), desktop());
+            assert.strictEqual(getPath("downloads"), downloads());
+            assert.strictEqual(getPath("documents"), documents());
+            assert.strictEqual(getPath("music"), music());
+            assert.strictEqual(getPath("pictures"), pictures());
+            assert.strictEqual(getPath("videos"), videos());
+        });
+
+        it("throws for unknown directory names", () => {
+            assert.throws(() => getPath("unknown"), /Unknown directory/);
+        });
+    });
+
+    describe("getXDGUserDir", () => {
+        const tmpDir = path.join(os.tmpdir(), "os-downloads-test");
+
+        beforeEach(() => {
+            fs.mkdirSync(tmpDir, { recursive: true });
+        });
+
+        afterEach(() => {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        const xdgEntries = [
+            { key: "XDG_DESKTOP_DIR", value: "Desktop" },
+            { key: "XDG_DOWNLOAD_DIR", value: "Downloads" },
+            { key: "XDG_DOCUMENTS_DIR", value: "Documents" },
+            { key: "XDG_MUSIC_DIR", value: "Music" },
+            { key: "XDG_PICTURES_DIR", value: "Pictures" },
+            { key: "XDG_VIDEOS_DIR", value: "Videos" },
+        ];
+
+        xdgEntries.forEach(({ key, value }) => {
+            it(`parses ${key} with $HOME`, () => {
+                const configPath = path.join(tmpDir, "user-dirs.dirs");
+                fs.writeFileSync(configPath, `${key}="$HOME/${value}"\n`);
+                const result = getXDGUserDir(key, configPath);
+                assert.strictEqual(result, path.join(os.homedir(), value));
+            });
+        });
+
+        it("parses entry with absolute path", () => {
+            const configPath = path.join(tmpDir, "user-dirs.dirs");
+            fs.writeFileSync(configPath, 'XDG_DOWNLOAD_DIR="/custom/downloads"\n');
+            const result = getXDGUserDir("XDG_DOWNLOAD_DIR", configPath);
+            assert.strictEqual(result, path.normalize("/custom/downloads"));
+        });
+
+        it("parses correct entry among multiple entries", () => {
+            const configPath = path.join(tmpDir, "user-dirs.dirs");
+            const content = [
+                'XDG_DESKTOP_DIR="$HOME/Desktop"',
+                'XDG_DOWNLOAD_DIR="$HOME/MyDownloads"',
+                'XDG_DOCUMENTS_DIR="$HOME/Documents"',
+                'XDG_MUSIC_DIR="$HOME/Musik"',
+                'XDG_PICTURES_DIR="$HOME/Bilder"',
+                'XDG_VIDEOS_DIR="$HOME/Videos"',
+            ].join("\n");
+            fs.writeFileSync(configPath, content);
+
+            assert.strictEqual(
+                getXDGUserDir("XDG_DOWNLOAD_DIR", configPath),
+                path.join(os.homedir(), "MyDownloads")
+            );
+            assert.strictEqual(
+                getXDGUserDir("XDG_MUSIC_DIR", configPath),
+                path.join(os.homedir(), "Musik")
+            );
+            assert.strictEqual(
+                getXDGUserDir("XDG_PICTURES_DIR", configPath),
+                path.join(os.homedir(), "Bilder")
+            );
+        });
+
+        it("returns null when key is not present", () => {
+            const configPath = path.join(tmpDir, "user-dirs.dirs");
+            fs.writeFileSync(configPath, 'XDG_DESKTOP_DIR="$HOME/Desktop"\n');
+            const result = getXDGUserDir("XDG_DOWNLOAD_DIR", configPath);
+            assert.strictEqual(result, null);
+        });
+
+        it("returns null when config file does not exist", () => {
+            const configPath = path.join(tmpDir, "nonexistent");
+            const result = getXDGUserDir("XDG_DOWNLOAD_DIR", configPath);
+            assert.strictEqual(result, null);
+        });
+    });
+
+    describe("getXDGDownloadDir (backward compatibility)", () => {
         const tmpDir = path.join(os.tmpdir(), "os-downloads-test");
 
         beforeEach(() => {
@@ -36,32 +157,6 @@ describe("os-downloads", () => {
             fs.writeFileSync(configPath, 'XDG_DOWNLOAD_DIR="$HOME/Downloads"\n');
             const result = getXDGDownloadDir(configPath);
             assert.strictEqual(result, path.join(os.homedir(), "Downloads"));
-        });
-
-        it("parses XDG_DOWNLOAD_DIR with absolute path", () => {
-            const configPath = path.join(tmpDir, "user-dirs.dirs");
-            fs.writeFileSync(configPath, 'XDG_DOWNLOAD_DIR="/custom/downloads"\n');
-            const result = getXDGDownloadDir(configPath);
-            assert.strictEqual(result, path.normalize("/custom/downloads"));
-        });
-
-        it("parses XDG_DOWNLOAD_DIR among other entries", () => {
-            const configPath = path.join(tmpDir, "user-dirs.dirs");
-            const content = [
-                'XDG_DESKTOP_DIR="$HOME/Desktop"',
-                'XDG_DOWNLOAD_DIR="$HOME/MyDownloads"',
-                'XDG_DOCUMENTS_DIR="$HOME/Documents"',
-            ].join("\n");
-            fs.writeFileSync(configPath, content);
-            const result = getXDGDownloadDir(configPath);
-            assert.strictEqual(result, path.join(os.homedir(), "MyDownloads"));
-        });
-
-        it("returns null when XDG_DOWNLOAD_DIR is not present", () => {
-            const configPath = path.join(tmpDir, "user-dirs.dirs");
-            fs.writeFileSync(configPath, 'XDG_DESKTOP_DIR="$HOME/Desktop"\n');
-            const result = getXDGDownloadDir(configPath);
-            assert.strictEqual(result, null);
         });
 
         it("returns null when config file does not exist", () => {


### PR DESCRIPTION
…ictures, videos)

Expand the library from Downloads-only to a cross-platform resolver for all standard user directories. Add getPath() for Electron-style access and named functions for each directory. Maintain full backward compatibility.