### PR TITLE
Rename package from os-downloads to os-user-dirs (v2.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,71 @@
-# os-downloads [![CI](https://github.com/piroz/os-downloads/actions/workflows/ci.yml/badge.svg)](https://github.com/piroz/os-downloads/actions/workflows/ci.yml)
-Look up downloads directory specific to different operating systems.
+# os-user-dirs [![CI](https://github.com/velocitylabo/os-user-dirs/actions/workflows/ci.yml/badge.svg)](https://github.com/velocitylabo/os-user-dirs/actions/workflows/ci.yml)
 
-# Supported platform
+Get OS-specific user directories (Downloads, Desktop, Documents, Music, Pictures, Videos) with zero dependencies.
 
-- windows
-- macos
-- linux
+> **Note:** This package was previously published as [`os-downloads`](https://www.npmjs.com/package/os-downloads). The old package is deprecated — please use `os-user-dirs` instead.
 
-# Install
+## Supported platforms
+
+- Windows
+- macOS
+- Linux (with XDG user-dirs.dirs support)
+
+## Install
 
 ```console
-$ npm install --save os-downloads
+$ npm install os-user-dirs
 ```
 
-# Usage
+## Usage
 
 ```javascript
-const downloads = require("os-downloads");
+const { downloads, desktop, documents, music, pictures, videos, getPath } = require("os-user-dirs");
 
 downloads();
-//=> 'C:\Users\Test\Downloads'
+//=> '/home/user/Downloads'
+
+desktop();
+//=> '/home/user/Desktop'
+
+documents();
+//=> '/home/user/Documents'
+
+getPath("music");
+//=> '/home/user/Music'
 ```
+
+### Default export (backward compatibility)
+
+```javascript
+const downloads = require("os-user-dirs");
+
+downloads();
+//=> '/home/user/Downloads'
+```
+
+## API
+
+### `downloads()`
+Returns the path to the Downloads directory.
+
+### `desktop()`
+Returns the path to the Desktop directory.
+
+### `documents()`
+Returns the path to the Documents directory.
+
+### `music()`
+Returns the path to the Music directory.
+
+### `pictures()`
+Returns the path to the Pictures directory.
+
+### `videos()`
+Returns the path to the Videos directory (Movies on macOS).
+
+### `getPath(name)`
+Returns the path to the specified directory. Valid names: `desktop`, `downloads`, `documents`, `music`, `pictures`, `videos`.
+
+## License
+
+MIT

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function music() { return resolve("music"); }
 function pictures() { return resolve("pictures"); }
 function videos() { return resolve("videos"); }
 
-// Backward compatibility: require("os-downloads")() returns Downloads path
+// Backward compatibility: require("os-user-dirs")() returns Downloads path
 module.exports = downloads;
 module.exports.getPath = getPath;
 module.exports.desktop = desktop;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "os-downloads",
-  "version": "1.0.0",
+  "name": "os-user-dirs",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "os-downloads",
-      "version": "1.0.0",
+      "name": "os-user-dirs",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "mocha": "^11.7.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "os-downloads",
-  "version": "1.0.0",
+  "name": "os-user-dirs",
+  "version": "2.0.0",
   "description": "Get OS-specific user directories (Downloads, Desktop, Documents, Music, Pictures, Videos) with zero dependencies.",
   "main": "index.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/velocitylabo/os-downloads.git"
+    "url": "git+https://github.com/velocitylabo/os-user-dirs.git"
   },
   "keywords": [
     "os",
@@ -26,9 +26,9 @@
   "author": "piroz",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/velocitylabo/os-downloads/issues"
+    "url": "https://github.com/velocitylabo/os-user-dirs/issues"
   },
-  "homepage": "https://github.com/velocitylabo/os-downloads#readme",
+  "homepage": "https://github.com/velocitylabo/os-user-dirs#readme",
   "devDependencies": {
     "mocha": "^11.7.5"
   }

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ const {
     videos,
 } = require("./");
 
-describe("os-downloads", () => {
+describe("os-user-dirs", () => {
     describe("downloads (default export / backward compatibility)", () => {
         it("returns a path ending with Downloads", () => {
             assert.ok(path.basename(downloads()).match(/downloads/i));
@@ -66,7 +66,7 @@ describe("os-downloads", () => {
     });
 
     describe("getXDGUserDir", () => {
-        const tmpDir = path.join(os.tmpdir(), "os-downloads-test");
+        const tmpDir = path.join(os.tmpdir(), "os-user-dirs-test");
 
         beforeEach(() => {
             fs.mkdirSync(tmpDir, { recursive: true });
@@ -142,7 +142,7 @@ describe("os-downloads", () => {
     });
 
     describe("getXDGDownloadDir (backward compatibility)", () => {
-        const tmpDir = path.join(os.tmpdir(), "os-downloads-test");
+        const tmpDir = path.join(os.tmpdir(), "os-user-dirs-test");
 
         beforeEach(() => {
             fs.mkdirSync(tmpDir, { recursive: true });


### PR DESCRIPTION
The package now supports multiple user directories (Desktop, Documents, Music, Pictures, Videos) beyond just Downloads, so the old name was misleading. Updated all references and README to reflect the new name. The old os-downloads package should be deprecated on npm.