### PR TITLE
fix(ci): fix OIDC trusted publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,20 +2,12 @@ name: Publish to npm
 
 on:
   push:
-    branches: [master]
+    tags:
+      - 'v*'
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm install
-      - run: npm test
-      - run: node test-esm.mjs
+    uses: ./.github/workflows/ci.yml
 
   publish:
     needs: test
@@ -29,5 +21,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
-      - run: npm publish --provenance
+      - run: npm install -g npm@11
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `setup-node` to prevent `NODE_AUTH_TOKEN` conflicting with OIDC authentication
- Upgrade npm to v11 (OIDC trusted publishing requires >= 11.5)
- Trigger publish on version tags (`v*`) instead of every push to master
- Make `ci.yml` reusable via `workflow_call` so publish reuses the full test matrix (3 OS × 2 Node versions)

## Test plan
- [x] Verify CI workflow still runs on push to master and PRs
- [ ] Tag a test version (e.g. `v2.1.1`) and confirm publish workflow triggers
- [ ] Confirm npm OIDC authentication succeeds and package is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)