### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [master]
+  workflow_dispatch: {}
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to release-please workflow so it can be manually triggered
- Needed to re-run release-please after adding the missing `v2.2.0` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)