### PR TITLE
Add guidelines for commit and PR session URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,10 @@
 # CLAUDE.md
 
+## Git commit / PR rules
+
+- コミットメッセージに `https://claude.ai/code/session_*` URL を含めないこと
+- PR タイトル・本文にもセッション URL を含めないこと
+
 ## Commit conventions
 
 Use conventional commits. release-please uses these to auto-generate changelogs and determine version bumps.


### PR DESCRIPTION
Added rules regarding the exclusion of session URLs in commit messages and PR titles.